### PR TITLE
Make apt_key support complex keyrings

### DIFF
--- a/lib/puppet/provider/apt_key/apt_key.rb
+++ b/lib/puppet/provider/apt_key/apt_key.rb
@@ -140,8 +140,7 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
     if name.size == 40
       if File.executable? command(:gpg)
         extracted_key = execute(["#{command(:gpg)} --with-fingerprint --with-colons #{file.path} | awk -F: '/^fpr:/ { print $10 }'"], :failonfail => false)
-        extracted_key = extracted_key.chomp
-        if extracted_key != name
+        if /^#{Regexp.escape(extracted_key)}$/m !~ extracted_key
           fail("The id in your manifest #{resource[:name]} and the fingerprint from content/source do not match. Please check there is not an error in the id or check the content/source is legitimate.")
         end
       else


### PR DESCRIPTION
It is valid for a downloaded apt-key keyring to include multiple public
keys so this switches the fingerprint validation to use a regexp so we
can check it against all public keys in the keyring.